### PR TITLE
datum: fix type of datum operator

### DIFF
--- a/lib/d3.ml
+++ b/lib/d3.ml
@@ -70,7 +70,7 @@ let html f = const_call "html" (mb (fun this d i () -> Js.string (f this d i)))
 let append name         = const_call "append" (Js.string name)
 let remove : ('a, 'a) t = thunk_call "remove"
 
-let datum f = const_call "datum" (fun d i -> Js.array (Array.of_list (f d i)))
+let datum f = const_call "datum" (fun d i -> f d i)
 let data  f = const_call "data"  (fun d i -> Js.array (Array.of_list (f d i)))
 
 let enter  : ('a, 'a) t = thunk_call "enter"

--- a/lib/d3.mli
+++ b/lib/d3.mli
@@ -163,7 +163,7 @@ val static : string -> ('a, 'a) t
 val data  : ('a -> int -> 'b list) -> ('a, 'b) t
 (** {{:https://github.com/mbostock/d3/wiki/Selections#data}D3.js docs} *)
 
-val datum : ('a -> int -> 'b list) -> ('a, 'b) t
+val datum : ('a -> int -> 'b) -> ('a, 'b) t
 (** {{:https://github.com/mbostock/d3/wiki/Selections#datum}D3.js docs} *)
 
 val enter : ('a, 'a) t


### PR DESCRIPTION
The `datum` operator does not introduce a data bind as the `data` operator does. It simply transforms the existing data that's attached to a node, and should therefore have a non-`list` return type. If the data attached to a node happens to be a list, that's ok given the new type.
