### PR TITLE
opam: fix dev-repo field

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -5,7 +5,7 @@ maintainer: "Spiros Eliopoulos <seliopou@gmail.com>"
 authors: [ "Spiros Eliopoulos <seliopou@gmail.com>" ]
 license: "BSD-3-clause"
 homepage: "https://github.com/seliopou/ocaml-d3"
-dev-repo: "https://github.com/inhabitedtype/ocaml-d3.git"
+dev-repo: "https://github.com/seliopou/ocaml-d3.git"
 bug-reports: "https://github.com/seliopou/ocaml-d3/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]


### PR DESCRIPTION
Suggest also updating the existing `opam` file in OPAM, unless making a release of `d3` soon.
